### PR TITLE
Fix two possible underflows that can generate long delays in loop

### DIFF
--- a/firmware/src/src.ino
+++ b/firmware/src/src.ino
@@ -491,14 +491,23 @@ void loop()
     send_rf_data();                                                           // *SEND RF DATA* - see emontx_lib
   }
 
+  unsigned long sleeptime = 0;
+  unsigned long max_runtime = (TIME_BETWEEN_READINGS*1000) - 100;
   unsigned long runtime = millis() - start;
-  unsigned long sleeptime = (TIME_BETWEEN_READINGS*1000) - runtime - 100;
+
+  if (runtime < max_runtime) {
+    sleeptime = max_runtime - runtime;
+  }
 
   if (ACAC) {                                                               // If powered by AC-AC adaper (mains power) then delay instead of sleep
     delay(sleeptime);
   } else {                                                                  // if powered by battery then sleep rather than delay and disable LED to reduce energy consumption
+    word time_to_loose = 0;
+    if (sleeptime > 500) {
+      time_to_loose = sleeptime-500;
+    }
                                    // lose an additional 500ms here (measured timing)
-    Sleepy::loseSomeTime(sleeptime-500);                                    // sleep or delay in milliseconds
+    Sleepy::loseSomeTime(time_to_loose);                                    // sleep or delay in milliseconds
   }
 } // end loop
 //-------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
In case the runtime calculated at the end of the loop is greater
than 9900 ms, the calculated sleeptime underflows. Being it an
unsigned long, the resulting value would be about 2^32
milliseconds (about 50 days). This value is used as parameter
in a delay() function to wait for the next acqusition cycle, if
AC-AC adapter is used.
Even in case of battery powered system, the time calculated
inside the Sleepy::loseSomeTime() function could underflow if
sleeptime is smaller than 500 ms. Being the parameter a word,
the resulting value would be about 2^16 (about 65 seconds).

This patch avoids both the underflows.
In case of underflow, a delay(0) or a Sleepy::loseSomeTime(0)
is executed, bringing the system to immediately start the next
acquisition cycle.

Signed-off-by: Roberto Bonacina <roby.bonacina@gmail.com>